### PR TITLE
Add support for NotificationEnabled option in indexer configuration

### DIFF
--- a/Util/Configuration/Settings.cs
+++ b/Util/Configuration/Settings.cs
@@ -74,6 +74,7 @@ namespace Util.Configuration
         public String ParExtraParameters { get; set; }
         public String MkvPropEditLocation { get; set; }
         public String FFmpegLocation { get; set; }
+        public Boolean NotificationEnabled { get; set; }
         public String NotificationType { get; set; }
         public String NzbPostFilenameParam { get; set; }
         public String NzbPostExtraParams { get; set; }

--- a/Util/Configuration/SettingsLoader.cs
+++ b/Util/Configuration/SettingsLoader.cs
@@ -170,6 +170,7 @@ namespace Util.Configuration
             settings.MaxConnectionCount = GetSettingInt(baseConfig, NewsHostSection, "MaxConnectionCount");
 
             const string IndexerSection = "Indexer";
+            settings.NotificationEnabled = GetSettingBoolean(baseConfig, IndexerSection, "NotificationEnabled");
             settings.NotificationType = GetSettingString(baseConfig, IndexerSection, "NotificationType");
             settings.MaxNotificationAttempts = GetSettingInt(baseConfig, IndexerSection, "MaxNotificationAttempts");
             settings.ObfuscatedNotificationUrl = GetSettingString(baseConfig, IndexerSection, "ObfuscatedNotificationUrl");

--- a/nntpAutoPosterWindowsService/Service.cs
+++ b/nntpAutoPosterWindowsService/Service.cs
@@ -58,6 +58,9 @@ namespace nntpAutoPosterWindowsService
                     {
                         log.Info("No notifier");
                     }
+                } else
+                {
+                    log.Info("Notifications disabled");
                 }
 
                 verifier = IndexerVerifierBase.GetActiveVerifier(configuration);

--- a/nntpAutoPosterWindowsService/Service.cs
+++ b/nntpAutoPosterWindowsService/Service.cs
@@ -47,15 +47,17 @@ namespace nntpAutoPosterWindowsService
                 poster.Start();
                 log.Info("Autoposter started");
 
-                notifier = IndexerNotifierBase.GetActiveNotifier(configuration);
-                if (notifier != null)
-                {
-                    notifier.Start();
-                    log.Info("Notifier started");
-                }
-                else
-                {
-                    log.Info("No notifier");
+                if (configuration.NotificationEnabled) { 
+                    notifier = IndexerNotifierBase.GetActiveNotifier(configuration);
+                    if (notifier != null)
+                    {
+                        notifier.Start();
+                        log.Info("Notifier started");
+                    }
+                    else
+                    {
+                        log.Info("No notifier");
+                    }
                 }
 
                 verifier = IndexerVerifierBase.GetActiveVerifier(configuration);


### PR DESCRIPTION
The NotificationEnabled option exists in the indexer configuration section to allow enabling or disabling notifications. 
However, until now this option was never actually used in the code.

This PR implements support for the NotificationEnabled flag, ensuring that notifications can be properly toggled on or off based on the configuration.